### PR TITLE
fix: open sidebar profile menu upward

### DIFF
--- a/components/layout/design-foundation.test.ts
+++ b/components/layout/design-foundation.test.ts
@@ -87,4 +87,21 @@ describe("approved premium application shell", () => {
     expect(css).toContain("env(safe-area-inset-bottom)");
     expect(mobile).toContain("env(safe-area-inset-bottom)");
   });
+
+  it("opens the desktop profile menu upward without changing its role links", () => {
+    const sidebar = readFileSync(
+      "components/layout/desktop-sidebar.tsx",
+      "utf8",
+    );
+
+    expect(sidebar).toContain('placement="top-end"');
+    expect(sidebar).toContain('href="/account"');
+    expect(sidebar).toContain("账号与设置");
+    expect(sidebar).toContain('viewer?.role === "ADMIN"');
+    expect(sidebar).toContain('href="/admin"');
+    expect(sidebar).toContain("系统管理");
+    expect(sidebar).toContain("min-h-0 flex-1");
+    expect(sidebar).toContain("overflow-y-auto");
+    expect(sidebar).toContain("mt-auto shrink-0");
+  });
 });

--- a/components/layout/desktop-sidebar.tsx
+++ b/components/layout/desktop-sidebar.tsx
@@ -40,7 +40,10 @@ export function DesktopSidebar({ viewer }: { viewer?: ShellViewer }) {
         </Link>
       </Button>
 
-      <nav aria-label="主导航" className="mt-6 space-y-5">
+      <nav
+        aria-label="主导航"
+        className="premium-scrollbar mt-6 min-h-0 flex-1 space-y-5 overflow-y-auto overscroll-contain pr-1"
+      >
         {navigationGroups.map((group) => (
           <section key={group.label}>
             <p className="mb-2 px-2.5 text-[.625rem] font-extrabold uppercase tracking-[.14em] text-muted-foreground">
@@ -83,7 +86,7 @@ export function DesktopSidebar({ viewer }: { viewer?: ShellViewer }) {
         ))}
       </nav>
 
-      <div className="mt-auto space-y-2.5">
+      <div className="mt-auto shrink-0 space-y-2.5">
         <div className="rounded-control border border-border/12 bg-surface/70 p-1.5">
           <p className="px-2 pb-1.5 pt-1 text-[.6875rem] font-semibold text-muted-foreground">
             外观
@@ -93,6 +96,7 @@ export function DesktopSidebar({ viewer }: { viewer?: ShellViewer }) {
 
         <Dropdown
           className="w-full"
+          placement="top-end"
           trigger={
             <span className="flex min-h-[3.25rem] w-full items-center gap-2.5 rounded-control border border-border/12 bg-surface/76 px-2.5 text-left transition-colors hover:bg-surface-raised">
               <Avatar

--- a/components/ui/dropdown-placement.ts
+++ b/components/ui/dropdown-placement.ts
@@ -1,0 +1,14 @@
+export type DropdownPlacement =
+  | "bottom-end"
+  | "bottom-start"
+  | "top-end"
+  | "top-start";
+
+export const DEFAULT_DROPDOWN_PLACEMENT: DropdownPlacement = "bottom-end";
+
+export const dropdownPlacementClasses: Record<DropdownPlacement, string> = {
+  "bottom-end": "top-full right-0 mt-2 origin-top-right",
+  "bottom-start": "top-full left-0 mt-2 origin-top-left",
+  "top-end": "bottom-full right-0 mb-2 origin-bottom-right",
+  "top-start": "bottom-full left-0 mb-2 origin-bottom-left",
+};

--- a/components/ui/dropdown.test.ts
+++ b/components/ui/dropdown.test.ts
@@ -1,0 +1,62 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_DROPDOWN_PLACEMENT,
+  dropdownPlacementClasses,
+} from "@/components/ui/dropdown-placement";
+
+describe("Dropdown placement", () => {
+  it("defaults existing callers to bottom-end", () => {
+    expect(DEFAULT_DROPDOWN_PLACEMENT).toBe("bottom-end");
+    expect(readFileSync("components/ui/dropdown.tsx", "utf8")).toContain(
+      "placement = DEFAULT_DROPDOWN_PLACEMENT",
+    );
+  });
+
+  it("maps bottom-end to downward end alignment", () => {
+    const classes = dropdownPlacementClasses["bottom-end"].split(" ");
+
+    expect(classes).toEqual(
+      expect.arrayContaining([
+        "top-full",
+        "right-0",
+        "mt-2",
+        "origin-top-right",
+      ]),
+    );
+  });
+
+  it("maps top-end upward without conflicting direction classes", () => {
+    const classes = dropdownPlacementClasses["top-end"].split(" ");
+
+    expect(classes).toEqual(
+      expect.arrayContaining([
+        "bottom-full",
+        "right-0",
+        "mb-2",
+        "origin-bottom-right",
+      ]),
+    );
+    expect(classes).not.toContain("top-full");
+    expect(classes).not.toContain("mt-2");
+  });
+
+  it("keeps every placement free of conflicting axis and margin classes", () => {
+    for (const classes of Object.values(dropdownPlacementClasses)) {
+      const tokens = classes.split(" ");
+      expect(tokens).not.toEqual(expect.arrayContaining(["top-full", "bottom-full"]));
+      expect(tokens).not.toEqual(expect.arrayContaining(["left-0", "right-0"]));
+      expect(tokens).not.toEqual(expect.arrayContaining(["mt-2", "mb-2"]));
+    }
+  });
+
+  it("keeps the panel inside the viewport and scrolls long content", () => {
+    const dropdown = readFileSync("components/ui/dropdown.tsx", "utf8");
+
+    expect(dropdown).toContain("max-h-[calc(100dvh-2rem)]");
+    expect(dropdown).toContain("max-w-[calc(100vw-2rem)]");
+    expect(dropdown).toContain("overflow-y-auto");
+    expect(dropdown).toContain("overflow-x-hidden");
+    expect(dropdown).toContain("z-50");
+  });
+});

--- a/components/ui/dropdown.tsx
+++ b/components/ui/dropdown.tsx
@@ -1,5 +1,54 @@
 import type { DetailsHTMLAttributes, ReactNode } from "react";
+import {
+  DEFAULT_DROPDOWN_PLACEMENT,
+  dropdownPlacementClasses,
+  type DropdownPlacement,
+} from "@/components/ui/dropdown-placement";
 import { cn } from "@/lib/utils";
-export function Dropdown({ trigger, children, className, ...props }: DetailsHTMLAttributes<HTMLDetailsElement> & { trigger: ReactNode }) { return <details className={cn("group relative", className)} {...props}><summary className="list-none cursor-pointer rounded-control [&::-webkit-details-marker]:hidden">{trigger}</summary><div className="absolute right-0 z-40 mt-2 min-w-48 rounded-overlay border border-border/14 bg-surface-raised p-1.5 shadow-overlay">{children}</div></details>; }
+
+interface DropdownProps extends DetailsHTMLAttributes<HTMLDetailsElement> {
+  trigger: ReactNode;
+  placement?: DropdownPlacement;
+}
+
+export function Dropdown({
+  trigger,
+  children,
+  className,
+  placement = DEFAULT_DROPDOWN_PLACEMENT,
+  ...props
+}: DropdownProps) {
+  return (
+    <details className={cn("group relative", className)} {...props}>
+      <summary className="list-none cursor-pointer rounded-control [&::-webkit-details-marker]:hidden">
+        {trigger}
+      </summary>
+      <div
+        className={cn(
+          "absolute z-50 min-w-48 max-w-[calc(100vw-2rem)] max-h-[calc(100dvh-2rem)] overflow-x-hidden overflow-y-auto overscroll-contain break-words rounded-overlay border border-border/14 bg-surface-raised p-1.5 opacity-0 shadow-overlay transition-[opacity,transform] duration-fast group-open:opacity-100 motion-reduce:transform-none motion-reduce:transition-none",
+          dropdownPlacementClasses[placement],
+        )}
+      >
+        {children}
+      </div>
+    </details>
+  );
+}
+
 export const Popover = Dropdown;
-export function DropdownItem({ className, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) { return <button className={cn("flex min-h-10 w-full items-center gap-2 rounded-control px-3 text-left text-sm text-muted-foreground hover:bg-surface-muted hover:text-foreground", className)} type="button" {...props} />; }
+
+export function DropdownItem({
+  className,
+  ...props
+}: React.ButtonHTMLAttributes<HTMLButtonElement>) {
+  return (
+    <button
+      className={cn(
+        "flex min-h-10 w-full items-center gap-2 rounded-control px-3 text-left text-sm text-muted-foreground hover:bg-surface-muted hover:text-foreground",
+        className,
+      )}
+      type="button"
+      {...props}
+    />
+  );
+}


### PR DESCRIPTION
## 问题

桌面侧栏账号资料栏位于视口底部，但通用 Dropdown 只支持固定向下展开的 `right-0 mt-2` 定位，导致账号菜单越过浏览器底部。

## 修复

- 为 Dropdown 增加 `bottom-end`、`bottom-start`、`top-end`、`top-start` 四种轻量定位；默认保持 `bottom-end`，现有调用行为不变。
- 四种定位分别使用互斥的 top/bottom、left/right、margin 类，并匹配对应 transform origin。
- Dropdown 面板增加视口最大高度/宽度、内部纵向滚动、横向隐藏、长文字换行、`z-50` 和 reduced-motion 保护。
- DesktopSidebar 账号菜单显式使用 `placement="top-end"`，菜单从触发器上方展开、右缘对齐并保留 8px 间距。
- 为 150% 高缩放下的短视口，让中间导航区域独立滚动，并保持底部外观/账号区固定可见；Sidebar 本身不增加会裁剪 Dropdown 的 overflow。

## 权限与交互

- 普通 USER 继续显示“账号与设置”，链接仍为 `/account`。
- ADMIN 继续额外显示“系统管理”，链接仍为 `/admin`。
- 未修改认证、权限判断、导航目标或其他 Dropdown 调用。

## 测试

- 新增 Dropdown 默认定位、bottom-end、top-end、互斥定位类、transform origin 和视口滚动保护测试。
- 扩展 DesktopSidebar 测试，覆盖 `top-end`、USER/ADMIN 链接和短视口导航滚动结构。
- `pnpm test`：76 个测试文件、425 项测试全部通过。
- `pnpm lint`：通过，0 warnings。
- `pnpm typecheck`：通过。
- `pnpm build`：通过，无真实 AI Key。
- `pnpm exec prisma validate`：通过。

## 真实布局检查

- 100%：821、1024、1180、1440px 均向上展开，无水平溢出或侧栏裁剪。
- 125% / 150%：使用 1440px 窗口的等效 CSS 视口 1152×640 / 960×533 检查；底部资料栏保持可见，菜单仍向上展开。
- 浅色与深色主题正常。
- 普通账号菜单和 ADMIN 双项菜单均保持 8px 间距、右缘对齐；`/account` 与 `/admin` 实际可点击。

## 严格范围

仅修改 Dropdown、DesktopSidebar 和对应测试。未修改 Prisma Schema、migration、RLS、API、数据库、Supabase、认证业务、AI Provider、Chat、Persona、Memory、Tools、环境变量或部署配置。
